### PR TITLE
feat: update Motoko recipe to use Mops

### DIFF
--- a/recipes/motoko/recipe.hbs
+++ b/recipes/motoko/recipe.hbs
@@ -18,10 +18,6 @@ build:
 
     - type: script
       commands:
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "moc:version" -d "$(moc --version)" --keep-name-section
-
-    - type: script
-      commands:
         - command -v ic-wasm >/dev/null 2>&1 || { echo >&2 "ic-wasm not found. To install ic-wasm, see https://github.com/dfinity/ic-wasm \n"; exit 1; }
         - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "cargo:version" -d "$(cargo --version)" --keep-name-section
         - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "template:type" -d "motoko" --keep-name-section


### PR DESCRIPTION
Updates the Motoko recipe to use Mops in place of dfx to manage the compiler version and dependencies.

Also adds an `args` parameter to the recipe to pass additional compiler flags, equivalent to dfx.

BREAKING CHANGE: renames `entry` to `main` and expects a `mops.toml` file in the same directory as `icp.yaml`.
