### PR TITLE
fix: Fix motoko candid logic

### DIFF
--- a/recipes/motoko/recipe.hbs
+++ b/recipes/motoko/recipe.hbs
@@ -10,7 +10,7 @@ build:
     - type: script
       commands:
         - sh -c 'command -v mops >/dev/null 2>&1 || { echo >&2 "'mops' not found on path. To install Mops, see https://mops.one/docs/install.\n"; exit 1; }'
-        - sh -c '$(mops toolchain bin moc) "{{ main }}" {{ args }} {{#if !candid}}--public-metadata candid:service {{/if}}$(mops sources) -o "$ICP_WASM_OUTPUT_PATH"'
+        - sh -c '$(mops toolchain bin moc) "{{ main }}" {{ args }} {{#if candid}}--omit-metadata{{else}}--public-metadata{{/if}} candid:service $(mops sources) -o "$ICP_WASM_OUTPUT_PATH"'
 
     - type: script
       commands:


### PR DESCRIPTION
ic-wasm won't overwrite the existing private service, so it needs to be omitted.