### PR TITLE
chore: Use release URL for asset canister

### DIFF
--- a/recipes/asset-canister/recipe.hbs
+++ b/recipes/asset-canister/recipe.hbs
@@ -18,12 +18,10 @@ build:
     {{/if}}
 
     - type: pre-built
-      {{! There is no convenient way to define defaults }}
       {{#if version}}
-      url: https://github.com/dfinity/sdk/raw/refs/tags/{{ version }}/src/distributed/assetstorage.wasm.gz
+      url: https://github.com/dfinity/sdk/releases/download/{{ version }}/assetstorage.wasm.gz
       {{else}}
-      {{! TODO We needed a latest tag on the sdk repo and adjust the README once we use it}}
-      url: https://github.com/dfinity/sdk/raw/refs/tags/0.30.2/src/distributed/assetstorage.wasm.gz
+      url: https://github.com/dfinity/sdk/releases/latest/download/assetstorage.wasm.gz
       {{/if}}
 
     {{#if metadata}}


### PR DESCRIPTION
Historical releases have been updated so this should be usable unconditionally.