### PR TITLE
feat: Lookup the target cargo directory

### DIFF
--- a/recipes/rust/recipe.hbs
+++ b/recipes/rust/recipe.hbs
@@ -17,10 +17,12 @@ build:
         - command -v gzip >/dev/null 2>&1 || { echo >&2 "gzip not found. Please install gzip to compress build output. \n"; exit 1; }
         {{/if}}
 
+    {{! We get the target directory from `cargo metadata` with sed in order not to in introduce a dependency on jq }}
+    {{! We do this because the target directory might be outside of current directory if we are running in a cargo workspace }}
     - type: script
       commands:
         - cargo build --package {{ package }} --target wasm32-unknown-unknown --release
-        - mv target/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script
       commands:


### PR DESCRIPTION
* Instead of moving the wasm, we simply copy it in order to avoid rebuilding unnecessarily
* Lookup the cargo target path so we can tolerate cargo workspaces more easily