### PR TITLE
docs: remove `-latest` references and require versioned recipe types

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,11 +99,6 @@ To create a new release for a recipe:
 
 2. **The workflow automatically**:
    - Creates a GitHub release for `rust-v4.0.0` with changelog and release artifacts
-   - Updates the `rust-latest` tag to point to the same commit as `rust-v4.0.0`
-   - Creates/updates the `rust-latest` release with:
-     - The same changelog as `rust-v4.0.0`
-     - The same release artifacts (but named with "latest")
-     - A fresh timestamp showing when it was updated
 
 ### Release Naming Convention
 
@@ -119,23 +114,6 @@ Release notes are automatically generated and include:
 - All commits affecting the specific recipe directory since the previous version
 - A link to the full changelog comparing the two versions
 - Release artifacts (tar.gz, zip files, checksums)
-
-### What is the `-latest` Release?
-
-Each recipe has two types of releases:
-
-1. **Versioned releases** (e.g., `rust-v4.0.0`):
-   - Permanent, immutable releases
-   - Pin to specific versions for stability
-   - Example: `rust-v4.0.0`, `rust-v3.0.0`, etc.
-
-2. **Latest release** (e.g., `rust-latest`):
-   - Always points to the most recent version
-   - Updated automatically when a new version is released
-   - Same content as the newest versioned release, but with:
-     - Updated timestamp
-     - "latest" naming for artifacts
-   - Use this to always get the newest recipe version
 
 ### Viewing Releases
 

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,10 @@ release-recipes:
 	@for recipe in $$(ls recipes/); do \
 		echo "Creating tag for $$recipe: $$recipe-$(VERSION_TAG)"; \
 		git tag -a "$$recipe-$(VERSION_TAG)" -m "Release $$recipe recipe $(VERSION_TAG)"; \
-		echo "Creating/updating latest tag for $$recipe: $$recipe-latest"; \
-		git tag -a "$$recipe-latest" -m "Latest $$recipe recipe ($(VERSION_TAG))" -f; \
 	done
 	@echo "Pushing all recipe tags..."
 	@for recipe in $$(ls recipes/); do \
 		git push origin "$$recipe-$(VERSION_TAG)"; \
-		git push origin "$$recipe-latest" -f; \
 	done
 	@echo "All recipe release tags created! GitHub Actions will build and publish the releases."
 
@@ -48,8 +45,5 @@ release-recipe:
 	fi
 	@echo "Creating $(RECIPE) recipe release tag: $(RECIPE)-$(VERSION_TAG)"
 	git tag -a $(RECIPE)-$(VERSION_TAG) -m "Release $(RECIPE) recipe $(VERSION_TAG)"
-	@echo "Creating/updating latest tag: $(RECIPE)-latest"
-	git tag -a $(RECIPE)-latest -m "Latest $(RECIPE) recipe ($(VERSION_TAG))" -f
 	git push origin $(RECIPE)-$(VERSION_TAG)
-	git push origin $(RECIPE)-latest -f
-	@echo "Release tags created! GitHub Actions will build and publish the releases."
+	@echo "Release tag created! GitHub Actions will build and publish the release."

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ canisters:
 ### Recipe Naming Convention
 
 Recipes follow the `@dfinity/<recipe-name>@<version>` naming pattern:
-- `@dfinity/rust` - Rust canister recipe
-- `@dfinity/motoko` - Motoko canister recipe
-- `@dfinity/pre-built` - Pre-built WASM recipe
-- `@dfinity/asset-canister` - Asset canister recipe
+- `@dfinity/rust@<version>` - Rust canister recipe
+- `@dfinity/motoko@<version>` - Motoko canister recipe
+- `@dfinity/pre-built@<version>` - Pre-built WASM recipe
+- `@dfinity/asset-canister@<version>` - Asset canister recipe
 
 ### Using Specific Versions
 

--- a/recipes/asset-canister/README.md
+++ b/recipes/asset-canister/README.md
@@ -10,17 +10,19 @@ Example of how to reference this recipe in an `icp.yaml` file:
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister"
+      type: "@dfinity/asset-canister@<version>"
       configuration:
         version: 0.30.2
         dir: dist
 ```
 
+> Replace `<version>` with a release version (e.g. `v2.1.0`). See [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=asset-canister&expanded=true).
+
 ## Configuration Parameters
 
 | Parameter | Type | Required | Description | Default |
 |-----------|------|----------|-------------|---------|
-| version | string | No | SDK version tag to download the assets canister from (e.g., `0.30.2`) | latest |
+| version | string | No | SDK version tag to download the asset canister from (e.g., `0.30.2`) | latest |
 | dir | string | Yes | Directory containing frontend assets to synchronize to the canister | - |
 | build | array | No | Shell commands to build the frontend assets before deployment (e.g., `npm run build`) | [] |
 | metadata | array | No | Array of key-value pairs for custom metadata to inject into the WASM | [] |
@@ -41,7 +43,7 @@ canisters:
 canisters:
   - name: website
     recipe:
-      type: "@dfinity/asset-canister"
+      type: "@dfinity/asset-canister@<version>"
       configuration:
         dir: build
 ```
@@ -52,7 +54,7 @@ canisters:
 canisters:
   - name: spa-frontend
     recipe:
-      type: "@dfinity/asset-canister"
+      type: "@dfinity/asset-canister@<version>"
       configuration:
         version: 0.30.2
         build:

--- a/recipes/motoko/README.md
+++ b/recipes/motoko/README.md
@@ -10,11 +10,13 @@ Example of how to reference this recipe in an `icp.yaml` file:
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/motoko"
+      type: "@dfinity/motoko@<version>"
       configuration:
         main: src/main.mo
         shrink: true
 ```
+
+> Replace `<version>` with a release version (e.g. `v4.0.0`). See [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=motoko&expanded=true).
 
 ## Configuration Parameters
 
@@ -46,7 +48,7 @@ If mops is not installed, see: <https://mops.one/docs/install>
 canisters:
   - name: hello-world
     recipe:
-      type: "@dfinity/motoko"
+      type: "@dfinity/motoko@<version>"
       configuration:
         main: src/main.mo
 ```
@@ -57,7 +59,7 @@ canisters:
 canisters:
   - name: complex-backend
     recipe:
-      type: "@dfinity/motoko"
+      type: "@dfinity/motoko@<version>"
       configuration:
         main: src/backend.mo
         args: --incremental-gc

--- a/recipes/prebuilt/README.md
+++ b/recipes/prebuilt/README.md
@@ -10,7 +10,7 @@ Example of how to reference this recipe in an `icp.yaml` file:
 canisters:
   - name: my-canister
     recipe:
-      type: "@dfinity/prebuilt"
+      type: "@dfinity/prebuilt@<version>"
       configuration:
         path: dist/canister.wasm
         sha256: 17a05e36278cd04c7ae6d3d3226c136267b9df7525a0657521405e22ec96be7a
@@ -20,6 +20,8 @@ canisters:
           - name: "custom:version"
             value: "1.0.0"
 ```
+
+> Replace `<version>` with a release version (e.g. `v2.0.0`). See [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=prebuilt&expanded=true).
 
 ## Configuration Parameters
 
@@ -48,7 +50,7 @@ canisters:
 canisters:
   - name: simple-canister
     recipe:
-      type: "@dfinity/prebuilt"
+      type: "@dfinity/prebuilt@<version>"
       configuration:
         path: target/wasm32-unknown-unknown/release/my_canister.wasm
         sha256: abc123def456...
@@ -60,7 +62,7 @@ canisters:
 canisters:
   - name: optimized-canister
     recipe:
-      type: "@dfinity/prebuilt"
+      type: "@dfinity/prebuilt@<version>"
       configuration:
         path: dist/production-canister.wasm
         sha256: xyz789abc123...

--- a/recipes/rust/README.md
+++ b/recipes/rust/README.md
@@ -10,11 +10,13 @@ Example of how to reference this recipe in an `icp.yaml` file:
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust"
+      type: "@dfinity/rust@<version>"
       configuration:
         package: my-canister
         shrink: true
 ```
+
+> Replace `<version>` with a release version (e.g. `v3.0.0`). See [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=rust&expanded=true).
 
 ## Configuration Parameters
 
@@ -53,7 +55,7 @@ cargo install candid-extractor
 canisters:
   - name: hello-rust
     recipe:
-      type: "@dfinity/rust"
+      type: "@dfinity/rust@<version>"
       configuration:
         package: hello-rust
 ```
@@ -64,7 +66,7 @@ canisters:
 canisters:
   - name: dapp-backend
     recipe:
-      type: "@dfinity/rust"
+      type: "@dfinity/rust@<version>"
       configuration:
         package: dapp-backend
         shrink: true


### PR DESCRIPTION
Follow-up to #21.

Update recipe READMEs, Makefile, and `CONTRIBUTING.md` to reflect that `-latest` tags are no longer used and recipe types must include an explicit `@<version>`.