### PR TITLE
feat: add `locked` option to Rust recipe

### DIFF
--- a/recipes/rust/README.md
+++ b/recipes/rust/README.md
@@ -23,6 +23,7 @@ canisters:
 | Parameter | Type    | Required | Description                                  | Default                   |
 |-----------|---------|----------|----------------------------------------------|---------------------------|
 | package   | string  | Yes      | Name of the Rust package to build            | -                         |
+| locked    | boolean | No       | Use exact dependency versions from `Cargo.lock` (passes `--locked` to Cargo) | false                     |
 | candid    | string  | No       | Path to a custom Candid interface file. If not provided, the interface is auto-extracted from the WASM using `candid-extractor` | (auto-extracted) |
 | metadata  | array   | No       | Array of key-value pairs for custom metadata | []                        |
 | shrink    | boolean | No       | Remove unused functions and debug info to reduce file size | false                     |
@@ -82,7 +83,7 @@ canisters:
 
 When this recipe is executed:
 
-1. Runs `cargo build` with the specified package for the `wasm32-unknown-unknown` target in release mode
+1. Runs `cargo build` with the specified package for the `wasm32-unknown-unknown` target in release mode (with `--locked` if enabled)
 2. Moves the resulting WASM file from the Cargo target directory to the output location
 3. Handles package name conversion (hyphens to underscores for the WASM filename)
 4. Injects Cargo version metadata ("cargo:version")

--- a/recipes/rust/recipe.hbs
+++ b/recipes/rust/recipe.hbs
@@ -1,5 +1,6 @@
 {{! A recipe for building a rust canister }}
 {{! `package: string` The package to build }}
+{{! `locked: boolean` Uses the exact dependency versions from Cargo.lock }}
 {{! `candid: string` The path to the Candid interface file }}
 {{! `shrink: boolean` Optimizes the wasm with ic-wasm }}
 {{! `compress: boolean` determines whether the wasm should be gzipped }}
@@ -21,7 +22,7 @@ build:
     {{! We do this because the target directory might be outside of current directory if we are running in a cargo workspace }}
     - type: script
       commands:
-        - cargo build --package {{ package }} --target wasm32-unknown-unknown --release
+        - cargo build --package {{ package }} --target wasm32-unknown-unknown --release{{#if locked}} --locked{{/if}}
         - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script


### PR DESCRIPTION
## Summary
- Add optional `locked` boolean parameter to the Rust recipe
- When enabled, passes `--locked` to `cargo build` ensuring exact dependency versions from `Cargo.lock` are used
- Useful for reproducible builds in CI environments