### PR TITLE
fix: use triple-brace interpolation to prevent HTML-escaping

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,7 +30,7 @@ build:
   steps:
     - type: script
       commands:
-        - command using {{ param }}
+        - command using {{{ param }}}
 
     {{#if optional_param}}
     - type: script
@@ -41,10 +41,14 @@ build:
 
 ## Key Patterns
 
+### Triple-Brace Interpolation
+
+Always use triple-braces `{{{ param }}}` for value interpolation. Handlebars double-braces `{{ param }}` HTML-escape the output (e.g. `&&` becomes `&amp;&amp;`), which breaks shell commands and is never correct in YAML/shell context.
+
 ### Required vs Optional Parameters
 
-- **Required parameters**: Used directly as `{{ param }}` - will cause strict mode error if missing
-- **Optional parameters**: Wrapped in conditionals `{{#if param}}{{ param }}{{/if}}`
+- **Required parameters**: Used directly as `{{{ param }}}` - will cause strict mode error if missing
+- **Optional parameters**: Wrapped in conditionals `{{#if param}}{{{ param }}}{{/if}}`
 
 ### Common Configuration Options
 

--- a/recipes/asset-canister/recipe.hbs
+++ b/recipes/asset-canister/recipe.hbs
@@ -19,13 +19,13 @@ build:
     - type: script
       commands:
         {{#each build}}
-        - {{ this }}
+        - {{{ this }}}
         {{/each}}
     {{/if}}
 
     - type: pre-built
       {{#if version}}
-      url: https://github.com/dfinity/sdk/releases/download/{{ version }}/assetstorage.wasm.gz
+      url: https://github.com/dfinity/sdk/releases/download/{{{ version }}}/assetstorage.wasm.gz
       {{else}}
       url: https://github.com/dfinity/sdk/releases/latest/download/assetstorage.wasm.gz
       {{/if}}
@@ -34,7 +34,7 @@ build:
     - type: script
       commands:
         {{#each metadata}}
-        - sh -c 'ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section'
+        - sh -c 'ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{{ name }}}" -d "{{{ value }}}" --keep-name-section'
         {{/each}}
     {{/if}}
 
@@ -42,4 +42,4 @@ build:
 sync:
   steps:
     - type: assets
-      dir: {{ dir }}
+      dir: {{{ dir }}}

--- a/recipes/motoko/recipe.hbs
+++ b/recipes/motoko/recipe.hbs
@@ -19,7 +19,7 @@ build:
 
     - type: script
       commands:
-        - sh -c '$(mops toolchain bin moc) "{{ main }}" {{#if args}}{{ args }} {{/if}}{{#if candid}}--omit-metadata{{else}}--public-metadata{{/if}} candid:service $(mops sources) -o "$ICP_WASM_OUTPUT_PATH"'
+        - sh -c '$(mops toolchain bin moc) "{{{ main }}}" {{#if args}}{{{ args }}} {{/if}}{{#if candid}}--omit-metadata{{else}}--public-metadata{{/if}} candid:service $(mops sources) -o "$ICP_WASM_OUTPUT_PATH"'
 
     - type: script
       commands:
@@ -29,11 +29,11 @@ build:
       commands:
         - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "template:type" -d "motoko" --keep-name-section
         {{#if candid}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "candid:service" -f '{{ candid }}' -v public --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "candid:service" -f '{{{ candid }}}' -v public --keep-name-section
         {{/if}}
         {{#if metadata}}
         {{#each metadata}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{{ name }}}" -d "{{{ value }}}" --keep-name-section
         {{/each}}
         {{/if}}
 

--- a/recipes/prebuilt/recipe.hbs
+++ b/recipes/prebuilt/recipe.hbs
@@ -23,16 +23,16 @@ build:
         {{/if}}
 
     - type: pre-built
-      path: {{ path }}
+      path: {{{ path }}}
       {{#if sha256 }}
-      sha256: {{ sha256 }}
+      sha256: {{{ sha256 }}}
       {{/if}}
 
     {{#if metadata}}
     - type: script
       commands:
         {{#each metadata}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{{ name }}}" -d "{{{ value }}}" --keep-name-section
         {{/each}}
     {{/if}}
 

--- a/recipes/rust/recipe.hbs
+++ b/recipes/rust/recipe.hbs
@@ -22,21 +22,21 @@ build:
     {{! We do this because the target directory might be outside of current directory if we are running in a cargo workspace }}
     - type: script
       commands:
-        - cargo build --package {{ package }} --target wasm32-unknown-unknown --release{{#if locked}} --locked{{/if}}
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - cargo build --package {{{ package }}} --target wasm32-unknown-unknown --release{{#if locked}} --locked{{/if}}
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{{ replace "-" "_" package }}}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script
       commands:
         - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "cargo:version" -d "$(cargo --version)" --keep-name-section
         - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "template:type" -d "rust" --keep-name-section
         {{#if candid}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "candid:service" -f '{{ candid }}' -v public --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "candid:service" -f '{{{ candid }}}' -v public --keep-name-section
         {{else}}
         - did="$(mktemp)"; candid-extractor "$ICP_WASM_OUTPUT_PATH" >"$did" && ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "candid:service" -f "$did" -v public --keep-name-section
         {{/if}}
         {{#if metadata}}
         {{#each metadata}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{{ name }}}" -d "{{{ value }}}" --keep-name-section
         {{/each}}
         {{/if}}
 


### PR DESCRIPTION
## Summary
- Switch all Handlebars value interpolations from `{{ }}` to `{{{ }}}` across all four recipe templates (asset-canister, motoko, prebuilt, rust)
- Handlebars double-braces HTML-escape output by default (e.g. `&&` → `&amp;&amp;`), which breaks shell commands in the generated YAML
- Add triple-brace interpolation guidance to CLAUDE.md

Fixes #24