### PR TITLE
feat(asset-canister): sync plugin

### DIFF
--- a/recipes/asset-canister/README.md
+++ b/recipes/asset-canister/README.md
@@ -2,6 +2,9 @@
 
 Download and configure the official IC assets canister with asset synchronization capabilities.
 
+> [!IMPORTANT]
+> Version `v2.2.0` and later of this recipe require **icp-cli v0.2.7 or later**.
+
 ## Usage
 
 Example of how to reference this recipe in an `icp.yaml` file:

--- a/recipes/asset-canister/recipe.hbs
+++ b/recipes/asset-canister/recipe.hbs
@@ -41,5 +41,8 @@ build:
 {{! Synchronize assets }}
 sync:
   steps:
-    - type: assets
-      dir: {{ dir }}
+    - type: plugin
+      url: https://github.com/dfinity/certified-assets/releases/download/migration-v2.2.0-209d688/sync_plugin.wasm
+      sha256: 297c2ef05680d47ac70688d6cebed9bc3a41b2302f400739f894f4f413e6a5ee
+      dirs:
+        - {{ dir }}


### PR DESCRIPTION
Switch to `sync_plugin` without changing the canister wasm.

### Context

This swaps the asset-canister recipe's sync step from the built-in `type: assets` mechanism to `type: plugin`, **without changing the canister wasm** — it remains the legacy dfx `assetstorage` canister. The goal is to ease the upgrade path for existing asset-canister users once `type: assets` sync is dropped in the upcoming icp-cli release: their canister stays the same, only the sync mechanism changes.

The plugin wasm is pinned to a pre-release hosted on the certified-assets repo:
- URL: `https://github.com/dfinity/certified-assets/releases/download/migration-v2.2.0-209d688/sync_plugin.wasm`
- sha256: `297c2ef05680d47ac70688d6cebed9bc3a41b2302f400739f894f4f413e6a5ee`

That plugin is built from the **`migration`** branch of `dfinity/certified-assets`, a permanently separate branch (never merged into `main`) dedicated to producing a sync plugin that targets the *legacy* assetstorage canister and reads `.ic-assets.json5` config:
- Branch: https://github.com/dfinity/certified-assets/tree/migration
- Plugin source / rationale: https://github.com/dfinity/certified-assets/pull/71
- Release hosting this wasm: https://github.com/dfinity/certified-assets/releases/tag/migration-v2.2.0-209d688

The `v2.2.0` in the tag tracks this recipe version (current latest is `asset-canister-v2.1.0`); the `-209d688` suffix pins the exact commit the wasm was built from. Future recipe bumps will get a matching `migration-vX.Y.Z-<hash>` release.