### PR TITLE
fix(asset-canister): bump sync plugin to v2.2.1

### DIFF
--- a/recipes/asset-canister/recipe.hbs
+++ b/recipes/asset-canister/recipe.hbs
@@ -42,7 +42,7 @@ build:
 sync:
   steps:
     - type: plugin
-      url: https://github.com/dfinity/certified-assets/releases/download/migration-v2.2.0-209d688/sync_plugin.wasm
-      sha256: 297c2ef05680d47ac70688d6cebed9bc3a41b2302f400739f894f4f413e6a5ee
+      url: https://github.com/dfinity/certified-assets/releases/download/migration-v2.2.1-6b48585/sync_plugin.wasm
+      sha256: ca7cb5666c30d2875f8d5e10535f8a53f97a86c79c263f7d5bdac2fdd1bbf83c
       dirs:
         - {{ dir }}


### PR DESCRIPTION
Bumps the asset-canister recipe's sync plugin to the new `migration-v2.2.1-6b48585` release on [dfinity/certified-assets](https://github.com/dfinity/certified-assets/releases/tag/migration-v2.2.1-6b48585).

## Why
A user reported that `icp deploy` failed during sync when the recipe's `dir` was a **nested** path such as `src/frontend/dist`:

```
failed to run plugin
  caused by: plugin returned error: canonicalize src/frontend/dist: No such file or directory (os error 44)
```

The v2.2.0 plugin called `canonicalize` during its scan step. Under WASI that calls `realpath`, which returns `ENOENT` for any path beneath a preopened directory whose guest name has more than one component (e.g. `src/frontend/dist`) — even though ordinary access works. Single-component dirs like `dist` happened to work, which is why our examples didn't catch it. The v2.2.1 plugin drops `canonicalize`; fix + regression test in dfinity/certified-assets#71.

## Change
Only `recipes/asset-canister/recipe.hbs` — the plugin `url` + `sha256`:

| | old (v2.2.0) | new (v2.2.1) |
|---|---|---|
| url | `…/migration-v2.2.0-209d688/sync_plugin.wasm` | `…/migration-v2.2.1-6b48585/sync_plugin.wasm` |
| sha256 | `297c2ef0…` | `ca7cb566…` |

The canister wasm is unchanged (still the legacy dfx `assetstorage` canister), so this is a drop-in patch bump for existing users.

## Releasing
After merge, push the `asset-canister-v2.2.1` tag to trigger `release-recipe.yml` and publish the recipe release.

Ref: https://forum.dfinity.org/t/icp-cli-announcements-and-feedback-discussion/60410/97