### PR TITLE
feat: add optional `visibility` to metadata entries

### DIFF
--- a/recipes/asset-canister/README.md
+++ b/recipes/asset-canister/README.md
@@ -28,7 +28,7 @@ canisters:
 | version | string | No | SDK version tag to download the asset canister from (e.g., `0.30.2`) | latest |
 | dir | string | Yes | Directory containing frontend assets to synchronize to the canister | - |
 | build | array | No | Shell commands to build the frontend assets before deployment (e.g., `npm run build`) | [] |
-| metadata | array | No | Array of key-value pairs for custom metadata to inject into the WASM | [] |
+| metadata | array | No | Custom wasm metadata entries. Each takes `name`, `value`, and an optional `visibility` of `public` or `private` (omitted means private) | [] |
 
 ## Prerequisites
 
@@ -69,6 +69,9 @@ canisters:
             value: "react"
           - name: "frontend:version"
             value: "1.0.0"
+          - name: "build:commit"
+            value: "a1b2c3d"
+            visibility: public
 ```
 
 ## Build Process

--- a/recipes/asset-canister/recipe.hbs
+++ b/recipes/asset-canister/recipe.hbs
@@ -2,7 +2,7 @@
 {{! `version: string` Optional, The version of the asset canister to use. Defaults to the master branch}}
 {{! `dir: string` Required, the directory of assets to synchronize }}
 {{! `build: [string]` Optional, array of commands to build the frontend assets before deployment }}
-{{! `metadata: [name: string, value: string]`: An array of name/value pairs that get injected into the wasm metadata section }}
+{{! `metadata: [{name: string, value: string, visibility: string}]`: An array of entries that get injected into the wasm metadata section. `visibility` is optional, `public` or `private`; omitted means private, ic-wasm's default }}
 
 build:
 
@@ -34,7 +34,7 @@ build:
     - type: script
       commands:
         {{#each metadata}}
-        - sh -c 'ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section'
+        - sh -c 'ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}"{{#if visibility}} -v {{ visibility }}{{/if}} --keep-name-section'
         {{/each}}
     {{/if}}
 

--- a/recipes/motoko/README.md
+++ b/recipes/motoko/README.md
@@ -33,7 +33,7 @@ Compiler flags, per-canister args, and the Candid file are all configured in `mo
 
 | Parameter | Type    | Required | Description                                  | Default |
 |-----------|---------|----------|----------------------------------------------|---------|
-| metadata  | array   | No       | Array of key-value pairs for custom metadata | []      |
+| metadata  | array   | No       | Custom wasm metadata entries. Each takes `name`, `value`, and an optional `visibility` of `public` or `private` (omitted means private) | []      |
 | shrink    | boolean | No       | Remove unused functions and debug info to reduce file size | false   |
 | compress  | boolean | No       | Gzip compress the WASM file                  | false   |
 
@@ -83,6 +83,9 @@ canisters:
         metadata:
           - name: "canister:type"
             value: "backend"
+          - name: "build:commit"
+            value: "a1b2c3d"
+            visibility: public
 ```
 
 ```toml

--- a/recipes/motoko/recipe.hbs
+++ b/recipes/motoko/recipe.hbs
@@ -1,7 +1,7 @@
 {{! A recipe for building a Motoko canister using `mops build` }}
 {{! `shrink: boolean` Optimizes the wasm with ic-wasm }}
 {{! `compress: boolean` determines whether the wasm should be gzipped }}
-{{! `metadata: [name: string, value: string]`: An array of name/value pairs that get injected into the wasm metadata section }}
+{{! `metadata: [{name: string, value: string, visibility: string}]`: An array of entries that get injected into the wasm metadata section. `visibility` is optional, `public` or `private`; omitted means private, ic-wasm's default }}
 
 build:
   steps:
@@ -28,7 +28,7 @@ build:
         - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "template:type" -d "motoko" --keep-name-section
         {{#if metadata}}
         {{#each metadata}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}"{{#if visibility}} -v {{ visibility }}{{/if}} --keep-name-section
         {{/each}}
         {{/if}}
 

--- a/recipes/prebuilt/README.md
+++ b/recipes/prebuilt/README.md
@@ -31,7 +31,7 @@ canisters:
 | sha256 | string | No | SHA256 hash for integrity verification. Generate with `sha256sum <file>.wasm` | - |
 | shrink | boolean | No | Remove unused functions and debug info to reduce file size | false |
 | compress | boolean | No | Gzip compress the WASM file | false |
-| metadata | array | No | Array of key-value pairs for custom metadata to inject into the WASM | [] |
+| metadata | array | No | Custom wasm metadata entries. Each takes `name`, `value`, and an optional `visibility` of `public` or `private` (omitted means private) | [] |
 
 ## Prerequisites
 
@@ -73,6 +73,9 @@ canisters:
             value: "2.1.0"
           - name: "build:environment"
             value: "production"
+          - name: "build:commit"
+            value: "a1b2c3d"
+            visibility: public
           - name: "build:timestamp"
             value: "2024-01-01T00:00:00Z"
 ```

--- a/recipes/prebuilt/recipe.hbs
+++ b/recipes/prebuilt/recipe.hbs
@@ -3,7 +3,7 @@
 {{! `sha256: string` Optional, the hash of the wasm to deploy}}
 {{! `shrink: boolean` Optimizes the wasm with ic-wasm }}
 {{! `compress: boolean` determines whether the wasm should be gzipped }}
-{{! `metadata: [name: string, value: string]`: An array of name/value pairs that get injected into the wasm metadata section }}
+{{! `metadata: [{name: string, value: string, visibility: string}]`: An array of entries that get injected into the wasm metadata section. `visibility` is optional, `public` or `private`; omitted means private, ic-wasm's default }}
 
 build:
 
@@ -32,7 +32,7 @@ build:
     - type: script
       commands:
         {{#each metadata}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}"{{#if visibility}} -v {{ visibility }}{{/if}} --keep-name-section
         {{/each}}
     {{/if}}
 

--- a/recipes/rust/README.md
+++ b/recipes/rust/README.md
@@ -26,7 +26,7 @@ By convention the canister `name` in `icp.yaml` should match the `[package] name
 | package   | string  | No       | Cargo package name to build. Defaults to the canister name in `icp.yaml` | (canister name) |
 | locked    | boolean | No       | Use exact dependency versions from `Cargo.lock` (passes `--locked` to Cargo) | false                     |
 | candid    | string  | No       | Path to a custom Candid interface file. If not provided, the interface is auto-extracted from the WASM using `candid-extractor` | (auto-extracted) |
-| metadata  | array   | No       | Array of key-value pairs for custom metadata | []                        |
+| metadata  | array   | No       | Custom wasm metadata entries. Each takes `name`, `value`, and an optional `visibility` of `public` or `private` (omitted means private) | []                        |
 | shrink    | boolean | No       | Remove unused functions and debug info to reduce file size | false                     |
 | compress  | boolean | No       | Gzip compress the WASM file                  | false                     |
 
@@ -75,6 +75,9 @@ canisters:
             value: "1.0.0"
           - name: "build:profile"
             value: "release"
+          - name: "build:commit"
+            value: "a1b2c3d"
+            visibility: public
 ```
 
 ### Workspace Example

--- a/recipes/rust/recipe.hbs
+++ b/recipes/rust/recipe.hbs
@@ -4,7 +4,7 @@
 {{! `candid: string` The path to the Candid interface file }}
 {{! `shrink: boolean` Optimizes the wasm with ic-wasm }}
 {{! `compress: boolean` determines whether the wasm should be gzipped }}
-{{! `metadata: [name: string, value: string]`: An array of name/value pairs that get injected into the wasm metadata section }}
+{{! `metadata: [{name: string, value: string, visibility: string}]`: An array of entries that get injected into the wasm metadata section. `visibility` is optional, `public` or `private`; omitted means private, ic-wasm's default }}
 
 build:
   steps:
@@ -36,7 +36,7 @@ build:
         {{/if}}
         {{#if metadata}}
         {{#each metadata}}
-        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "${ICP_WASM_OUTPUT_PATH}" metadata "{{ name }}" -d "{{ value }}"{{#if visibility}} -v {{ visibility }}{{/if}} --keep-name-section
         {{/each}}
         {{/if}}
 

--- a/recipes/static-site/README.md
+++ b/recipes/static-site/README.md
@@ -26,7 +26,7 @@ canisters:
 | dir | string | Yes | The single directory of built assets to synchronize to the canister | - |
 | build | array | No | Shell commands run before sync to produce the asset directory (e.g. `npm run build`) | [] |
 | presync | array | No | Shell commands run at sync time (after the canister exists), with the deployed canister IDs in the environment — see [Pre-sync environment](#pre-sync-environment) | [] |
-| metadata | array | No | Name/value pairs injected into the canister wasm via `ic-wasm` | [] |
+| metadata | array | No | Entries injected into the canister wasm via `ic-wasm`. Each takes `name`, `value`, and an optional `visibility` of `public` or `private` (omitted means private) | [] |
 
 > The sync plugin owns the canister's full URL space and accepts **exactly one** asset directory, so `dir` is a single string rather than a list.
 
@@ -66,6 +66,9 @@ canisters:
         metadata:
           - name: "frontend:framework"
             value: "react"
+          - name: "build:commit"
+            value: "a1b2c3d"
+            visibility: public
 ```
 
 ### With a pre-sync build that needs canister IDs

--- a/recipes/static-site/recipe.hbs
+++ b/recipes/static-site/recipe.hbs
@@ -2,7 +2,7 @@
 {{! `dir: string` Required. The single directory of built assets to synchronize. }}
 {{! `build: [string]` Optional. Commands run before sync to produce the asset directory. }}
 {{! `presync: [string]` Optional. Commands run at sync time (after the canister exists), before assets upload, with the deployed canister IDs in the environment: ICP_CLI_CID, ICP_CLI_CID_<NAME>, ICP_CLI_NETWORK, ICP_CLI_ENVIRONMENT. }}
-{{! `metadata: [{name, value}]` Optional. Pairs injected into the canister wasm via ic-wasm. }}
+{{! `metadata: [{name, value, visibility}]` Optional. Entries injected into the canister wasm via ic-wasm. `visibility` is optional, `public` or `private`; omitted means private, ic-wasm's default. }}
 
 build:
   steps:
@@ -25,7 +25,7 @@ build:
     - type: script
       commands:
         {{#each metadata}}
-        - sh -c 'ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "$ICP_WASM_OUTPUT_PATH" metadata "{{ name }}" -d "{{ value }}" --keep-name-section'
+        - sh -c 'ic-wasm "$ICP_WASM_OUTPUT_PATH" -o "$ICP_WASM_OUTPUT_PATH" metadata "{{ name }}" -d "{{ value }}"{{#if visibility}} -v {{ visibility }}{{/if}} --keep-name-section'
         {{/each}}
     {{/if}}
 


### PR DESCRIPTION
Exposes ic-wasm's metadata visibility to users, per metadata entry.

Today every recipe that takes a `metadata` parameter injects the sections with
`ic-wasm … metadata "<name>" -d "<value>" --keep-name-section` and never passes
`-v`, so user metadata always lands private with no way to change it — readable
only by a controller. The recipes clearly need the distinction themselves
(`recipes/rust/recipe.hbs:33` passes `-v public` for `candid:service`); this makes
the same choice reachable from `icp.yaml`:

```yaml
        metadata:
          - name: build:commit
            value: a1b2c3d
            visibility: public      # optional; private when omitted
```

The template change is one line per recipe, using the optional-parameter pattern
from `.claude/CLAUDE.md`:

```diff
-        - ic-wasm … metadata "{{ name }}" -d "{{ value }}" --keep-name-section
+        - ic-wasm … metadata "{{ name }}" -d "{{ value }}"{{#if visibility}} -v {{ visibility }}{{/if}} --keep-name-section
```

**Backward compatible.** Omitting `visibility` renders byte-for-byte the command
emitted before this change, so existing configurations build identically.

### Scope

All five recipes that expose a user-facing `metadata` parameter: `motoko`, `rust`,
`static-site`, `asset-canister`, `prebuilt`. CONTRIBUTING asks for one fix per PR
and this is one change — but it lands in five files for consistency, since a
`visibility` that worked in only some recipes would be its own papercut. Happy to
split it per recipe if you'd rather review them separately.

Per `.claude/CLAUDE.md`'s documentation-verification rules, each recipe also gets:
its `{{! metadata: … }}` doc-comment updated to describe the new field, its README
parameter-table row updated, and one README example extended so the option is
copy-pasteable. No version tags touched — releases are made via `make
release-recipe`. `icp-cli/docs/guides/using-recipes.md` does not mention
`metadata`, so no cross-repo doc sync is needed.

### Testing

Following the `icp project show` → `icp build` procedure in `.claude/CLAUDE.md`,
with recipes referenced via `type: file://…` (icp-cli 1.2.0, ic-wasm 0.9.11).

Rendering, via `icp project show` — public, omitted, and a mixed list:

```
- ic-wasm … metadata "build:commit" -d "abc123" -v public --keep-name-section
- ic-wasm … metadata "build:commit" -d "abc123" --keep-name-section
- ic-wasm … metadata "pub:sect" -d "p" -v public --keep-name-section
- ic-wasm … metadata "priv:sect" -d "q" --keep-name-section
```

Note the omitted case renders correctly under icp-cli's handlebars **strict mode**.

Resulting sections after `icp build`, read back with `ic-wasm <wasm> metadata`:

| Config | Recipe | Section |
| --- | --- | --- |
| `visibility: public` | prebuilt | `icp:public build:commit` |
| omitted | prebuilt | `icp:private build:commit` |
| mixed list | prebuilt | `icp:public pub:sect` + `icp:private priv:sect` |
| `visibility: public` + omitted | static-site | `icp:public build:commit` + `icp:private build:private` |

`static-site` is covered separately because it wraps the call in `sh -c '…'`, a
different quoting shape from the bare command in `motoko` / `rust` / `prebuilt`.

Invalid values fail at build time with ic-wasm's own message, so no template-side
validation is needed:

```
ERR [bad] > error: invalid value 'bogus' for '--visibility <VISIBILITY>'
ERR [bad] >   [possible values: public, private]
Error: Canister(s) ["bad"] failed to build.
```

### Motivation

We bake a `service:git` section (commit sha + repo origin) into all 33 canisters of
a suite so a deployed canister can be traced back to the commit that built it. The
natural consumer is a launcher frontend showing each app's deployed version, which
reads sections anonymously — invisible while the section is private. Details in #33.

Ref: #33
