### PR TITLE
feat(static-site): publish v0.3.2

### DIFF
--- a/recipes/static-site/recipe.hbs
+++ b/recipes/static-site/recipe.hbs
@@ -19,8 +19,8 @@ build:
         {{/each}}
     {{/if}}
     - type: pre-built
-      url: https://github.com/dfinity/certified-assets/releases/download/v0.3.1/canister-release.wasm.gz
-      sha256: 450ff311b283df72212c76dc36827b530b64c0091eb7982f342df74e378be1b6
+      url: https://github.com/dfinity/certified-assets/releases/download/v0.3.2/canister-release.wasm.gz
+      sha256: eaa83f13c7b5d9aa9e012312556cf32afa66d9b287d3a7da1a9335ae97dedc2b
     {{#if metadata}}
     - type: script
       commands:
@@ -39,7 +39,7 @@ sync:
         {{/each}}
     {{/if}}
     - type: plugin
-      url: https://github.com/dfinity/certified-assets/releases/download/v0.3.1/plugin-release.wasm
-      sha256: af9e780faaf81293f3cae7785095fa5a9c2f3738f0664ad21d7d7480ab04e3bb
+      url: https://github.com/dfinity/certified-assets/releases/download/v0.3.2/plugin-release.wasm
+      sha256: aad9c2e657ee7adb1427438e92efe1092dec0dbd474280d1069bfb648a0aebe6
       dirs:
         - {{ dir }}


### PR DESCRIPTION
Publishes the `static-site` recipe at v0.3.2, pinning the canister and sync-plugin wasm from dfinity/certified-assets's v0.3.2 release.

The committed `recipe.hbs` is the asset attached to that release, verbatim — verify it matches:
https://github.com/dfinity/certified-assets/releases/download/v0.3.2/recipe.hbs

After merge, tag `static-site-v0.3.2` in this repo to cut the recipe release.

------

### Context: version ordering

This publishes `static-site-v0.3.2`, below the existing `static-site-v0.4.0`. That's
deliberate: the `static-site` recipe version tracks the certified-assets release it
pins, and v0.4.0 pins v0.3.1 artifacts. A minor bump upstream also carries a specific
meaning — breaking change, canister reinstall, every asset re-uploaded — which doesn't
apply here.

Sequence: merge this → tag `static-site-v0.3.2` → retire the `static-site-v0.4.0` tag
and release. One local checkout references it, coordinated directly.

#34's `visibility` option is unaffected: it was carried upstream in
[certified-assets#118](https://github.com/dfinity/certified-assets/pull/118), so it's in
the recipe committed here and the diff is only the two wasm pins. These files are
regenerated from that repo on each publish, so changes persist by landing there.